### PR TITLE
Fix auto-generate config.yaml fails when config directory is missing …

### DIFF
--- a/internal/config/generator.go
+++ b/internal/config/generator.go
@@ -6,6 +6,14 @@ import (
 )
 
 func GenerateDefaultConfig(path string) error {
+	dir := path[:len(path)-len("config.yaml")]
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		err := os.MkdirAll(dir, os.ModePerm)
+		if err != nil {
+			return err
+		}
+	}
+
 	cfg := Config{
 		WebhookURL: "https://example.com/webhook",
 		AvatarURL:  "",


### PR DESCRIPTION
…(#1)

## Summary
This RP fixes an issue where the application fails to automatically generate `config/config.yaml` when the `config` directory is missing.

## Related Issue
Closes #1 

## Changes
- Added a directory existence check before creating `config.yaml`
- If the `config` directory is not exists, it will now be automatically created before the file is generated.

## Test
- Verified that the application now creates both `config/` and `config.yaml` properly when `config` is missing.
- Confirmed no error is thrown.